### PR TITLE
Add complex test and benchmark for Jet

### DIFF
--- a/jet/blocks.jet
+++ b/jet/blocks.jet
@@ -1,0 +1,16 @@
+{{block header()}}
+<title>{{ .Title }}'s Home Page</title>
+<div class="header">Page Header</div>
+{{end}}
+
+{{block navigation()}}
+<ul class="navigation">
+  {{range .Nav}}
+    <li><a href="{{ .Link }}">{{ .Item }}</a></li>
+  {{end}}
+</ul>
+{{end}}
+
+{{block footer()}}
+<div class="footer">copyright 2016</div>
+{{end}}

--- a/jet/index.jet
+++ b/jet/index.jet
@@ -1,0 +1,20 @@
+{{extends "layout.jet"}}
+{{block Body()}}
+
+<div class="content">
+  <div class="welcome">
+    <h4>Hello {{ .User.FirstName }}</h4>
+
+    <div class="raw">{{ .User.RawContent|unsafe }}</div>
+    <div class="enc">{{ .User.EscapedContent }}</div>
+  </div>
+
+  {{range m := .Messages}}
+    {{if m.Plural}}
+      <p>{{ .User.FirstName }} has {{ m.I }} messages</p>
+    {{else}}
+      <p>{{ .User.FirstName }} has {{ m.I }} message</p>
+    {{end}}
+  {{end}}
+</div>
+{{end}}

--- a/jet/layout.jet
+++ b/jet/layout.jet
@@ -1,0 +1,23 @@
+{{import "blocks.jet"}}
+<!DOCTYPE html>
+<html>
+<body>
+
+<header>
+{{yield header()}}
+</header>
+
+<nav>
+{{yield navigation()}}
+</nav>
+
+<section>
+{{yield Body()}}
+</section>
+
+<footer>
+{{yield footer()}}
+</footer>
+
+</body>
+</html>

--- a/templates_complex_test.go
+++ b/templates_complex_test.go
@@ -318,3 +318,38 @@ func BenchmarkComplexGorazor(b *testing.B) {
 		gorazor.Index(testComplexUser, testComplexNav, testComplexTitle)
 	}
 }
+
+/******************************************************************************
+** Jet
+******************************************************************************/
+
+func TestComplexJetHTML(t *testing.T) {
+	var buf bytes.Buffer
+
+	tmpl, err := jetSet.GetTemplate("index.jet")
+	if err != nil {
+		t.Error(err)
+	}
+	err = tmpl.Execute(&buf, nil, testComplexData)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if msg, ok := linesEquals(buf.String(), expectedtComplexResult); !ok {
+		t.Error(msg)
+	}
+}
+
+func BenchmarkComplexJetHTML(b *testing.B) {
+	var buf bytes.Buffer
+
+	tmpl, _ := jetSet.GetTemplate("index.jet")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := tmpl.Execute(&buf, nil, testComplexData)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Jet supports template inheritance and extending a layout (among other things) so I added a complex test case and accompanying benchmark. Results are good for B/op and allocs/op:

```
go test . -bench="Complex" -benchmem -benchtime=3s
BenchmarkComplexGolang-8               	  100000       	     49658 ns/op       	   12415 B/op  	     295 allocs/op
BenchmarkComplexEgo-8                  	 1000000       	      6189 ns/op       	    2561 B/op  	      41 allocs/op
BenchmarkComplexQuicktemplate-8        	 2000000       	      3121 ns/op       	    1892 B/op  	       0 allocs/op
BenchmarkComplexEgon-8                 	  300000       	     11663 ns/op       	    4792 B/op  	     101 allocs/op
BenchmarkComplexEgoSlinso-8            	 2000000       	      2790 ns/op       	    2070 B/op  	       7 allocs/op
BenchmarkComplexFtmpl-8                	  500000       	      6435 ns/op       	    5300 B/op  	      48 allocs/op
BenchmarkComplexFtmplInclude-8         	 1000000       	      6505 ns/op       	    5300 B/op  	      48 allocs/op
BenchmarkComplexMustache-8             	  200000       	     26515 ns/op       	    7856 B/op  	     166 allocs/op
BenchmarkComplexGorazor-8              	  300000       	     12027 ns/op       	    8327 B/op  	      73 allocs/op
BenchmarkComplexJetHTML-8              	  300000       	     12083 ns/op       	    3561 B/op  	       5 allocs/op
PASS
```

Could you also add a link to the Jet repo in the README at the top to the »full featured template engines«, please? That'd be awesome!